### PR TITLE
When checking whether a rule matches, it just uses the data object

### DIFF
--- a/src/rule.js
+++ b/src/rule.js
@@ -10,24 +10,42 @@ var Rule = function(name, rules) {
 };
 
 /**
- * Checks if rule is matched
+ * Checks if rule is a match.
  *
- * @param {Object} obj1
- * @param {Object} obj2
- * @param {Object} data
+ * @param {Object} data Data to be used in rule execution
  * @returns {bool}
  **/
-Rule.prototype.isMatch = function(obj1, obj2, data) {
+Rule.prototype.isMatch = function(data) {
   var code, result;
 
   try {
-    code = new Function('obj1', 'obj2', 'data', this.rules), result;
-    result = code.apply({}, [ obj1, obj2, data ]);
+    // When I put this in a separate function, it doesn't work.
+    result = (new Function('data', this.rules)).apply({}, [ data ]);
   } catch (e) {
-    return false;
+    result = false;
   }
 
-  return !!result;
+  // Boolean value only. :D
+  return result === true;
+};
+
+/**
+ * Checks if rules are valid based on syntax and given data.
+ *
+ * @param {Object} data
+ * @returns {bool}
+ **/
+Rule.prototype.isValid = function(data) {
+  var result;
+  try {
+    // For some reason, if I place this code in another function, it doesn't work.
+    (new Function('data', this.rules)).apply({}, [ data ]);
+    result = true;
+  } catch (e) {
+    result = false;
+  }
+
+  return result;
 };
 
 exports.Rule = Rule;

--- a/test/rule-test.js
+++ b/test/rule-test.js
@@ -36,7 +36,7 @@ describe('Rule', function() {
         r = new RuleNS.Rule('name', rules);
 
       // Execute
-      var result = r.isMatch();
+      var result = r.isMatch({});
 
       // Verify
       assert.ok(result, 'Expects rule to match');
@@ -52,6 +52,31 @@ describe('Rule', function() {
 
       // Verify
       assert.ok(!result, 'Expects rule not to match.');
+    });
+
+    it('should return false when rules does not explicit return a value', function() {
+      // Setup
+      var rules = 'var hello = "world";',
+        r = new RuleNS.Rule('name', rules);
+
+      // Execute
+      var result = r.isMatch();
+
+      // Verify
+      assert.ok(!result, 'Expects rule not to match');
+    });
+
+    it('should evaluate rule based on given syntax when called', function() {
+      // Setup
+      var rules = 'return data.hello === "hello";',
+        r = new RuleNS.Rule('name', rules),
+        data = { hello: 'hello' };
+
+      // Execute
+      var result = r.isMatch(data);
+
+      // Verify
+      assert.ok(result, 'Expects rule to match');
     });
   });
 });


### PR DESCRIPTION
instead of the two objects.  (It's kinda pointless)
